### PR TITLE
Remove autoinsert

### DIFF
--- a/external/settings.vim
+++ b/external/settings.vim
@@ -4,9 +4,6 @@
 " To import files:
 " source $HOME/.config/usuim/file.vim
 
-" Autoinsert mode
-autocmd BufRead,BufNewFile,BufEnter * set formatoptions-=cro | start
-
 " Themes
 colorscheme vscode
 

--- a/init.lua
+++ b/init.lua
@@ -11,7 +11,5 @@ vim.cmd("source " .. vim.fn.expand("~/.config/usuim/lsp.vim"))
 vim.cmd("source " .. vim.fn.expand("~/.config/usuim/commands.vim"))
 vim.cmd("source " .. vim.fn.expand("~/.config/usuim/mapping.vim"))
 
--- Autoinsert
-require('autoinsert')
 -- Colors
 require('colors')


### PR DESCRIPTION
removed autoinsert mode

delete this line from `~/.config/usuim/settings.vim`
`autocmd BufRead,BufNewFile,BufEnter * set formatoptions-=cro | start`